### PR TITLE
Enable user to filter comments by awul_level 

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,21 @@
 loadRandomComment();
 
 function loadRandomComment(selected_awul_level) {
+    var previousComment = document.getElementById("athal-text").value
+    console.log("Previous Comment: "+ previousComment)
+    if(selected_awul_level==undefined){
+        selected_awul_level='shape'
+    }
     console.log(selected_awul_level)
     loadJSON(function (response) {
+        console.log(`${selected_awul_level} in loadJSON`)
         var comments = JSON.parse(response);
         var comment = comments[0]
         do{
             comment = comments[Math.floor(Math.random() * comments.length)]
         }
-        while(comment.awul_level != 'poddak');
+        while((comment.awul_level !== selected_awul_level) || (comment.comment === previousComment));
+
         document.getElementById("athal-text").value = comment.comment;
         document.getElementById("copybtn").innerHTML = "<i class='fa fa-copy'></i> Copy";
         var color = '#007bff'

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 loadRandomComment();
 
-function loadRandomComment() {
+function loadRandomComment(selected_awul_level) {
+    console.log(selected_awul_level)
     loadJSON(function (response) {
         var comments = JSON.parse(response);
         var comment = comments[Math.floor(Math.random() * comments.length)]

--- a/app.js
+++ b/app.js
@@ -2,20 +2,21 @@ loadRandomComment();
 
 function loadRandomComment(selected_awul_level) {
     var previousComment = document.getElementById("athal-text").value
-    console.log("Previous Comment: "+ previousComment)
     if(selected_awul_level==undefined){
-        selected_awul_level='shape'
+        selected_awul_level='oni_ekak'
     }
-    console.log(selected_awul_level)
     loadJSON(function (response) {
-        console.log(`${selected_awul_level} in loadJSON`)
         var comments = JSON.parse(response);
         var comment = comments[0]
-        do{
+        if(selected_awul_level!=='oni_ekak'){
+            do{
+                comment = comments[Math.floor(Math.random() * comments.length)]
+            }
+            while((comment.awul_level !== selected_awul_level) || (comment.comment === previousComment));
+        }
+        else{
             comment = comments[Math.floor(Math.random() * comments.length)]
         }
-        while((comment.awul_level !== selected_awul_level) || (comment.comment === previousComment));
-
         document.getElementById("athal-text").value = comment.comment;
         document.getElementById("copybtn").innerHTML = "<i class='fa fa-copy'></i> Copy";
         var color = '#007bff'

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ function loadRandomComment(selected_awul_level) {
         do{
             comment = comments[Math.floor(Math.random() * comments.length)]
         }
-        while(comment.awul_level != selected_awul_level);
+        while(comment.awul_level != 'poddak');
         document.getElementById("athal-text").value = comment.comment;
         document.getElementById("copybtn").innerHTML = "<i class='fa fa-copy'></i> Copy";
         var color = '#007bff'

--- a/app.js
+++ b/app.js
@@ -4,7 +4,11 @@ function loadRandomComment(selected_awul_level) {
     console.log(selected_awul_level)
     loadJSON(function (response) {
         var comments = JSON.parse(response);
-        var comment = comments[Math.floor(Math.random() * comments.length)]
+        var comment = comments[0]
+        do{
+            comment = comments[Math.floor(Math.random() * comments.length)]
+        }
+        while(comment.awul_level != selected_awul_level);
         document.getElementById("athal-text").value = comment.comment;
         document.getElementById("copybtn").innerHTML = "<i class='fa fa-copy'></i> Copy";
         var color = '#007bff'

--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
           <p style="color:white;font-size: 20px;">Awul Level: <span style="font-size: 24px;text-transform: uppercase;"
               class="badge badge-primary" id="athal-level"></span></p>
           <textarea readonly id="athal-text" class="form-control transparent" rows="7" style="margin-top:10px;"></textarea>
+          <select id="awul_level_select">
+            <option value="shape">ශේප්</option>
+            <option value="poddak">පොඩ්ඩක් විතර</option>
+            <option value="kunuharapa">කුණුහරප</option>
+          </select>
           <button style="margin-top:10px" class="btn btn-primary btn-fill btn-lg" onclick="loadRandomComment()"><i class="fa fa-refresh"></i>
             Generate</button>
             <p class="text-muted" style="font-size: 16px;">Total comments: <span id="athal-comments-count"></span></p>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
             <option value="poddak">පොඩ්ඩක් විතර</option>
             <option value="kunuharapa">කුණුහරප</option>
           </select>
-          <button style="margin-top:10px" class="btn btn-primary btn-fill btn-lg" onclick="loadRandomComment()"><i class="fa fa-refresh"></i>
+          <button style="margin-top:10px" class="btn btn-primary btn-fill btn-lg" onclick="loadRandomComment(awul_level_select.value)"><i class="fa fa-refresh"></i>
             Generate</button>
             <p class="text-muted" style="font-size: 16px;">Total comments: <span id="athal-comments-count"></span></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,8 @@
           <p style="color:white;font-size: 20px;">Awul Level: <span style="font-size: 24px;text-transform: uppercase;"
               class="badge badge-primary" id="athal-level"></span></p>
           <textarea readonly id="athal-text" class="form-control transparent" rows="7" style="margin-top:10px;"></textarea>
-          <select id="awul_level_select">
+          <select id="awul_level_select" style="margin-top:10px" class="btn btn-primary btn-fill btn-lg">
+            <option selected= "selected" value="oni_ekak">ඕනි එකක්</option>
             <option value="shape">ශේප්</option>
             <option value="poddak">පොඩ්ඩක් විතර</option>
             <option value="kunuharapa">කුණුහරප</option>


### PR DESCRIPTION
# Description
Fix to Issue #33
1. Allow users to filter the comment "awul_level" as they wish or give them the option to get comments from any "awul_level" (original logic).
2. Stopped generating the same comment on two continuous occasions.

# Motivation and Context
There are times users would need to generate comments from specific categories for specific people.

# Screenshots 
## Web View 1 - Before clicking select
![comment-generator](https://user-images.githubusercontent.com/35809841/77433543-80062680-6e05-11ea-8cf7-03cd56772cee.JPG)
This new select option is added to the UI for the user to select the category.

## Web View 2 - After clicking select
![comment-generator-2](https://user-images.githubusercontent.com/35809841/77433929-12a6c580-6e06-11ea-959a-1a33e3d6bf5f.JPG)

## Mobile View 1 - Before clicking select
![WhatsApp Image 2020-03-24 at 19 31 23](https://user-images.githubusercontent.com/35809841/77434274-9d87c000-6e06-11ea-87f7-d7671c5df332.jpeg)

## Mobile View 2 - After clicking select
![WhatsApp Image 2020-03-24 at 19 31 23 (1)](https://user-images.githubusercontent.com/35809841/77434296-a7a9be80-6e06-11ea-879a-12d64b64e0e0.jpeg)

# Main Changes Done
1. Added the filter for the users to filter comments based on categories
2. Stopped a comment from repeating on two continuous occasions
